### PR TITLE
validate aws env variables

### DIFF
--- a/docker_login_ecr.sh
+++ b/docker_login_ecr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID;
-aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY;
-DOCKER_LOGIN_CMD=`aws ecr get-login --region $AWS_REGION --no-include-email`;
+aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID?"empty aws_access_key"};
+aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY?"empty secret_access_key"};
+DOCKER_LOGIN_CMD=`aws ecr get-login --region ${AWS_REGION?"empty region"} --no-include-email`;
 
 eval $DOCKER_LOGIN_CMD

--- a/docker_login_ecr.sh
+++ b/docker_login_ecr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail 
+
 aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID?"empty aws_access_key"};
 aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY?"empty secret_access_key"};
 DOCKER_LOGIN_CMD=`aws ecr get-login --region ${AWS_REGION?"empty region"} --no-include-email`;


### PR DESCRIPTION
 - sets bash to fail early when error is thrown https://explainshell.com/explain?cmd=set+-euo+pipefail
 - validates aws env variables