### PR TITLE
Change TRAVIS_PULL_REQUEST_BRANCH to TRAVIS_PULL_REQUEST

### DIFF
--- a/changelog_checker.py
+++ b/changelog_checker.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+from subprocess import PIPE, DEVNULL
+
+
+def check_if_pull_request():
+    try:
+        # if build is a pull request TRAVIS_PULL_REQUEST holds PR number otherwise "false"
+        int(os.getenv('TRAVIS_PULL_REQUEST', ""))
+    except ValueError:
+        print("This is not a PR, skipping")
+        exit(0)
+
+
+def check_if_forced_skipping():
+    commit_msg = subprocess.run(["git", "log", "-2", "--pretty=%B"], stdout=PIPE).stdout.decode('ascii')
+    if "[skip cl]" in commit_msg:
+        print("Skipping changelog checking")
+        exit(0)
+
+
+def check_changelog():
+    if subprocess.run(
+            ["git", "diff", "--diff-filter=AM", "HEAD..${TRAVIS_BRANCH}", "--exit-code", "-s", "--", "CHANGELOG.md"],
+            stdout=DEVNULL, stderr=DEVNULL
+    ).returncode:
+        print("FAILED! Please update ./CHANGELOG.md file")
+        exit(1)
+
+    print("SUCCESS!")
+
+
+check_if_pull_request()
+check_if_forced_skipping()
+check_changelog()


### PR DESCRIPTION
Changelog linter doesn't work when you don't prking to master
I've prepared a dummy [PR](https://github.com/PiwikPRO/PPMS-LicenseManager/pull/59) to make sure it works - https://travis-ci.com/PiwikPRO/PPMS-LicenseManager/jobs/276293831#L221

I got a bit pissed off because I wasn't able to write pleasant if bash in less than 5 minutes that worked on sh/bash/zsh/ubuntu/mac/travis at once. I had a thought wtf am I doing it's 2020, why I even bother, this way I proposed python script (Travis uses python 3.6 by default). Do you like it?